### PR TITLE
Allow using net10.0 for C# 14

### DIFF
--- a/UnityEditorPatch/FodyWeavers.xsd
+++ b/UnityEditorPatch/FodyWeavers.xsd
@@ -29,12 +29,27 @@
               </xs:element>
               <xs:element minOccurs="0" maxOccurs="1" name="Unmanaged32Assemblies" type="xs:string">
                 <xs:annotation>
-                  <xs:documentation>A list of unmanaged 32 bit assembly names to include, delimited with line breaks.</xs:documentation>
+                  <xs:documentation>Obsolete, use UnmanagedWinX86Assemblies instead</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element minOccurs="0" maxOccurs="1" name="UnmanagedWinX86Assemblies" type="xs:string">
+                <xs:annotation>
+                  <xs:documentation>A list of unmanaged X86 (32 bit) assembly names to include, delimited with line breaks.</xs:documentation>
                 </xs:annotation>
               </xs:element>
               <xs:element minOccurs="0" maxOccurs="1" name="Unmanaged64Assemblies" type="xs:string">
                 <xs:annotation>
-                  <xs:documentation>A list of unmanaged 64 bit assembly names to include, delimited with line breaks.</xs:documentation>
+                  <xs:documentation>Obsolete, use UnmanagedWinX64Assemblies instead.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element minOccurs="0" maxOccurs="1" name="UnmanagedWinX64Assemblies" type="xs:string">
+                <xs:annotation>
+                  <xs:documentation>A list of unmanaged X64 (64 bit) assembly names to include, delimited with line breaks.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element minOccurs="0" maxOccurs="1" name="UnmanagedWinArm64Assemblies" type="xs:string">
+                <xs:annotation>
+                  <xs:documentation>A list of unmanaged Arm64 (64 bit) assembly names to include, delimited with line breaks.</xs:documentation>
                 </xs:annotation>
               </xs:element>
               <xs:element minOccurs="0" maxOccurs="1" name="PreloadOrder" type="xs:string">
@@ -73,6 +88,11 @@
                 <xs:documentation>As part of Costura, embedded assemblies are no longer included as part of the build. This cleanup can be turned off.</xs:documentation>
               </xs:annotation>
             </xs:attribute>
+            <xs:attribute name="DisableEventSubscription" type="xs:boolean">
+              <xs:annotation>
+                <xs:documentation>The attach method no longer subscribes to the `AppDomain.AssemblyResolve` (.NET 4.x) and `AssemblyLoadContext.Resolving` (.NET 6.0+) events.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
             <xs:attribute name="LoadAtModuleInit" type="xs:boolean">
               <xs:annotation>
                 <xs:documentation>Costura by default will load as part of the module initialization. This flag disables that behavior. Make sure you call CosturaUtility.Initialize() somewhere in your code.</xs:documentation>
@@ -105,12 +125,27 @@
             </xs:attribute>
             <xs:attribute name="Unmanaged32Assemblies" type="xs:string">
               <xs:annotation>
-                <xs:documentation>A list of unmanaged 32 bit assembly names to include, delimited with |.</xs:documentation>
+                <xs:documentation>Obsolete, use UnmanagedWinX86Assemblies instead</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UnmanagedWinX86Assemblies" type="xs:string">
+              <xs:annotation>
+                <xs:documentation>A list of unmanaged X86 (32 bit) assembly names to include, delimited with |.</xs:documentation>
               </xs:annotation>
             </xs:attribute>
             <xs:attribute name="Unmanaged64Assemblies" type="xs:string">
               <xs:annotation>
-                <xs:documentation>A list of unmanaged 64 bit assembly names to include, delimited with |.</xs:documentation>
+                <xs:documentation>Obsolete, use UnmanagedWinX64Assemblies instead</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UnmanagedWinX64Assemblies" type="xs:string">
+              <xs:annotation>
+                <xs:documentation>A list of unmanaged X64 (64 bit) assembly names to include, delimited with |.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UnmanagedWinArm64Assemblies" type="xs:string">
+              <xs:annotation>
+                <xs:documentation>A list of unmanaged Arm64 (64 bit) assembly names to include, delimited with |.</xs:documentation>
               </xs:annotation>
             </xs:attribute>
             <xs:attribute name="PreloadOrder" type="xs:string">

--- a/UnityEditorPatch/InfoProviders/Sdk/SDKInfoProvider.cs
+++ b/UnityEditorPatch/InfoProviders/Sdk/SDKInfoProvider.cs
@@ -7,7 +7,7 @@ namespace UnityEditorPatch.InfoProviders.Sdk;
 
 public static partial class SDKInfoProvider
 {
-    [GeneratedRegex(@"(\d+\.\d+\.\d+)[\s]\[(.+)\]", RegexOptions.Multiline)]
+    [GeneratedRegex(@"(\d+\.\d+\.\d+(?:-[\w\.]+)?)[\s]\[(.+)\]", RegexOptions.Multiline)]
     private static partial Regex SDKInfoRegex();
 
     public static bool TryGet(out SDKInfo info)

--- a/UnityEditorPatch/Interactors/SourceGeneratorPatch.cs
+++ b/UnityEditorPatch/Interactors/SourceGeneratorPatch.cs
@@ -1,6 +1,5 @@
 using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures;
-using AsmResolver.DotNet.Signatures.Types;
 using UnityEditorPatch.Extensions;
 using UnityEditorPatch.InfoProviders.Editor;
 

--- a/UnityEditorPatch/UnityEditorPatch.csproj
+++ b/UnityEditorPatch/UnityEditorPatch.csproj
@@ -1,29 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <DebugType>None</DebugType>
-        <DebugSymbols>false</DebugSymbols>
-        <Nullable>enable</Nullable>
-        <GenerateDependencyFile>false</GenerateDependencyFile>
-        <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-        <Platforms>AnyCPU</Platforms>
-        <Configurations>Debug;Release</Configurations>
-        <RootNamespace>UnityEditorPatch</RootNamespace>
-    </PropertyGroup>
-
-    <ItemGroup>
-        <PackageReference Include="AsmResolver.DotNet" Version="5.5.1"/>
-        <PackageReference Include="CommandLineParser" Version="2.9.1"/>
-        <PackageReference Include="Costura.Fody" Version="5.7.0">
-          <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="Fody" Version="6.8.1">
-          <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="NuGet.Versioning" Version="6.10.1"/>
-    </ItemGroup>
-
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <DebugType>None</DebugType>
+    <DebugSymbols>false</DebugSymbols>
+    <Nullable>enable</Nullable>
+    <GenerateDependencyFile>false</GenerateDependencyFile>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <Platforms>AnyCPU</Platforms>
+    <Configurations>Debug;Release</Configurations>
+    <RootNamespace>UnityEditorPatch</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="AsmResolver.DotNet" Version="6.0.0-beta.3" />
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
+    <PackageReference Include="Costura.Fody" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Fody" Version="6.9.2">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="NuGet.Versioning" Version="6.13.2" />
+  </ItemGroup>
 </Project>

--- a/UnityEditorPatch/UnityEditorPatch.csproj
+++ b/UnityEditorPatch/UnityEditorPatch.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <DebugType>None</DebugType>
     <DebugSymbols>false</DebugSymbols>


### PR DESCRIPTION
## Things done
- Update Dependencies
- Update SDK Regex to allow selecting Preview SDK like "10.0.100-preview.3.25201.16"
- C# 14 scripts verified to work on net10.0 patched editor.

https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-14

## Tested Snippets

```csharp
//👇I think this will be a lifesaver syntax sugar
public class NullConditionalAssignmentExample : MonoBehaviour
{
    private class Player
    {
        public int Health { get; set; }
    }

    private Player _player;

    private void Start()
    {
        _player?.Health = 100;
        _player = new Player { Health = 0 };
        _player?.Health += 25;

        Debug.Log($"Player health: {_player?.Health}"); //Outputs 25
    }
}
```


```csharp
public class UnboundNameofExample : MonoBehaviour
{
    private void Start()
    {
        Debug.Log(nameof(List<>));
        Debug.Log(nameof(Dictionary<,>));
        Debug.Log(nameof(HashSet<>));
    }
}
```


```csharp
public class ImplicitSpanConversionsExample : MonoBehaviour
{
    private void Start()
    {
        var values = new int[] { 1, 2, 3, 4, 5 };

        ProcessReadOnlySpan(values); // Array to ReadOnlySpan

        Span<int> span = values;
        ProcessReadOnlySpan(span); // Span to ReadOnlySpan
    }

    private static void ProcessReadOnlySpan(ReadOnlySpan<int> span)
    {
        Debug.Log($"Sum: {Sum(span)}");
    }

    private static int Sum(ReadOnlySpan<int> span)
    {
        int sum = 0;
        foreach (var value in span) sum += value;
        return sum;
    }
}
```

There's also partial event (I failed to wrote a working monobehavior example).

And I haven't covered all edge cases, as Rider haven't provide net10.0 support yet.

But indeed we can make use of C# 14 now🥰