### PR TITLE
C# 14 Support for the editor package

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,6 @@ where:
 Language Support
 ----------------
 
-> [!NOTE]
-> C# 14 features support of .net 10 in `Rider` / `Visual Studio` is still in development.
-> Code will compile and work, but you may suffer from errors in IDE.
-> Currently only `VSCode` supports all new features
-
 C# | Feature | Support
 -|-|:-----:
 14 | [`field` keyword](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-14#the-field-keyword) | Yes

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ where ``--editor`` - path to the unity editor
 ```
 where:
 
-- ``langVersion`` (optional) - C# version you want to be used for this ``.asmdef``. Values are ``10``, ``11``, ``12``, ``13``, ``preview``
+- ``langVersion`` (optional) - C# version you want to be used for this ``.asmdef``. Values are ``10``, ``11``, ``12``, ``13``, ``14``
 - ``nullable`` (optional) - allows to use nullables like ``string?`` without defining ``#nullable enable/disable`` in each file where it used. Values are ``enable``, ``disable``
 
 7. Refresh the Editor. All required magic should be done here.
@@ -79,19 +79,19 @@ Language Support
 ----------------
 
 > [!NOTE]
-> `preview` features support of .net 10 in `Rider` / `Visual Studio` is still in development.
+> C# 14 features support of .net 10 in `Rider` / `Visual Studio` is still in development.
 > Code will compile and work, but you may suffer from errors in IDE.
 > Currently only `VSCode` supports all new features
 
 C# | Feature | Support
 -|-|:-----:
-preview | [`field` keyword](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-14#the-field-keyword) | Yes
-preview | [`partial` events and instance constructors](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-14#more-partial-members) | Yes
-preview | [`nameof` unbound generic types support for](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-14#unbound-generic-types-and-nameof) | Yes
-preview | [Extension members](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-14#extension-members) | Yes
-preview | [Null conditional assignment](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-14#null-conditional-assignment) | Yes
-preview | [Simple lambda parameters](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-14#simple-lambda-parameters-with-modifiers) | Yes
-preview | [Implicit span conversions](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-14#implicit-span-conversions) | Yes
+14 | [`field` keyword](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-14#the-field-keyword) | Yes
+14 | [`partial` events and instance constructors](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-14#more-partial-members) | Yes
+14 | [`nameof` unbound generic types support for](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-14#unbound-generic-types-and-nameof) | Yes
+14 | [Extension members](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-14#extension-members) | Yes
+14 | [Null conditional assignment](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-14#null-conditional-assignment) | Yes
+14 | [Simple lambda parameters](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-14#simple-lambda-parameters-with-modifiers) | Yes
+14 | [Implicit span conversions](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-14#implicit-span-conversions) | Yes
 13 | [`params` collections](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-13#params-collections) | Yes
 13 | [New lock type and semantics](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-13#new-lock-object) | No
 13 | [New escape sequence - \\e](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-13#new-escape-sequence) | Yes

--- a/UnityCSharpPatch/Packages/com.kandreyc.unity-csharp-patch/Editor/Csc/CscParser.cs
+++ b/UnityCSharpPatch/Packages/com.kandreyc.unity-csharp-patch/Editor/Csc/CscParser.cs
@@ -12,6 +12,7 @@ namespace UnityCSharpPatch.Editor.Csc
             { "11", "11"},
             { "12", "12"},
             { "13", "13"},
+            { "14", "14" },
             { "preview", "preview"}
         };
 

--- a/UnityCSharpPatch/Packages/com.kandreyc.unity-csharp-patch/Editor/Csc/CscParser.cs
+++ b/UnityCSharpPatch/Packages/com.kandreyc.unity-csharp-patch/Editor/Csc/CscParser.cs
@@ -6,16 +6,6 @@ namespace UnityCSharpPatch.Editor.Csc
 {
     public static class CscParser
     {
-        private static readonly Dictionary<string, string> LangVersions = new()
-        {
-            { "10", "10"},
-            { "11", "11"},
-            { "12", "12"},
-            { "13", "13"},
-            { "14", "14" },
-            { "preview", "preview"}
-        };
-
         public static bool TryParse(string csc, out Dictionary<string, string> info)
         {
             if (!File.Exists(csc))
@@ -38,9 +28,9 @@ namespace UnityCSharpPatch.Editor.Csc
 
                 switch (name)
                 {
-                    case "-langVersion" when LangVersions.TryGetValue(key: value, out var version):
+                    case "-langVersion":
                     {
-                        info.TryAdd("langVersion", version);
+                        info.TryAdd("langVersion", value);
                         break;
                     }
                     case "-nullable" when value is "enable" or "disable":


### PR DESCRIPTION
Hi! I added C# 14 support to the editor package.

One question though - I’m not fully sure why we need this dictionary. Is it meant to block unsupported or untested versions? Personally, I think it might be unnecessary: this package already enables some features that Unity tooling may not fully support anyway, so being extra defensive here feels a bit redundant.

Either way, thanks for the great work on this project - hope you’ll consider accepting the PR :)