### PR TITLE
Add dynamic Roslyn path resolving for 6000.5+

### DIFF
--- a/UnityEditorPatch/InfoProviders/Editor/EditorInfo.cs
+++ b/UnityEditorPatch/InfoProviders/Editor/EditorInfo.cs
@@ -9,6 +9,8 @@ public class EditorInfo
     public string ContentLocation { get; init; }
     public string RuntimeLocation { get; init; }
     public string RoslynLocation { get; init; }
+    public string? DotNetSdkHostLocation { get; init; }
+    public string? DotNetSdkSharedLocation { get; init; }
     public string[] SourceGeneratorLocations { get; init; }
 }
 

--- a/UnityEditorPatch/InfoProviders/Editor/EditorInfoProvider.cs
+++ b/UnityEditorPatch/InfoProviders/Editor/EditorInfoProvider.cs
@@ -16,7 +16,7 @@ public static class EditorInfoProvider
 
         var contentPath = UnityLocationUtility.GetContentPath(lookupPath);
         var runtimePath = Path.Combine(contentPath, pathSpecification.RuntimePath);
-        var roslynPath = Path.Combine(contentPath, pathSpecification.RoslynLocation);
+        var roslynPath = ResolveRoslynPath(contentPath, pathSpecification.RoslynLocation);
         var sourceGeneratorLocations = pathSpecification.SourceGeneratorLocations
             .Select(location => Path.Combine(contentPath, location))
             .Where(File.Exists).ToArray();
@@ -38,5 +38,28 @@ public static class EditorInfoProvider
         };
 
         return true;
+    }
+
+    static string ResolveRoslynPath(string contentPath, string preferredRelativePath)
+    {
+        var preferredPath = Path.Combine(contentPath, preferredRelativePath);
+        if (Directory.Exists(preferredPath))
+        {
+            return preferredPath;
+        }
+
+        var dotNetSdkPath = Path.Combine(contentPath, "DotNetSdk", "sdk");
+        if (!Directory.Exists(dotNetSdkPath))
+        {
+            return preferredPath;
+        }
+
+        var roslynCandidates = Directory.GetDirectories(dotNetSdkPath)
+            .Select(versionPath => Path.Combine(versionPath, "Roslyn", "bincore"))
+            .Where(Directory.Exists)
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        return roslynCandidates.LastOrDefault() ?? preferredPath;
     }
 }

--- a/UnityEditorPatch/InfoProviders/Editor/EditorInfoProvider.cs
+++ b/UnityEditorPatch/InfoProviders/Editor/EditorInfoProvider.cs
@@ -17,6 +17,8 @@ public static class EditorInfoProvider
         var contentPath = UnityLocationUtility.GetContentPath(lookupPath);
         var runtimePath = Path.Combine(contentPath, pathSpecification.RuntimePath);
         var roslynPath = ResolveRoslynPath(contentPath, pathSpecification.RoslynLocation);
+        var dotNetSdkHostPath = ResolveDotNetSdkSubdirectory(contentPath, roslynPath, "host");
+        var dotNetSdkSharedPath = ResolveDotNetSdkSubdirectory(contentPath, roslynPath, "shared");
         var sourceGeneratorLocations = pathSpecification.SourceGeneratorLocations
             .Select(location => Path.Combine(contentPath, location))
             .Where(File.Exists).ToArray();
@@ -33,6 +35,8 @@ public static class EditorInfoProvider
             RoslynLocation = roslynPath,
             ContentLocation = contentPath,
             RuntimeLocation = runtimePath,
+            DotNetSdkHostLocation = dotNetSdkHostPath,
+            DotNetSdkSharedLocation = dotNetSdkSharedPath,
             IsPatched = Backup.IsBackupExist(contentPath),
             SourceGeneratorLocations = sourceGeneratorLocations
         };
@@ -61,5 +65,17 @@ public static class EditorInfoProvider
             .ToArray();
 
         return roslynCandidates.LastOrDefault() ?? preferredPath;
+    }
+
+    private static string? ResolveDotNetSdkSubdirectory(string contentPath, string roslynPath, string subdirectory)
+    {
+        var dotNetSdkPath = Path.Combine(contentPath, "DotNetSdk");
+        if (!roslynPath.StartsWith(dotNetSdkPath, StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var path = Path.Combine(dotNetSdkPath, subdirectory);
+        return Directory.Exists(path) ? path : null;
     }
 }

--- a/UnityEditorPatch/Interactors/Backup.cs
+++ b/UnityEditorPatch/Interactors/Backup.cs
@@ -26,6 +26,8 @@ public static class Backup
             Directory.CreateDirectory(backupPath);
             FileSystemUtility.CopyDirectory(info.RoslynLocation, BackupLocation(backupPath, info.RoslynLocation, relativeTo: info.ContentLocation));
             FileSystemUtility.CopyDirectory(info.RuntimeLocation, BackupLocation(backupPath, info.RuntimeLocation, relativeTo: info.ContentLocation));
+            BackupDirectoryIfExists(info.DotNetSdkHostLocation, backupPath, info.ContentLocation);
+            BackupDirectoryIfExists(info.DotNetSdkSharedLocation, backupPath, info.ContentLocation);
 
             foreach (var sourceGeneratorLocation in info.SourceGeneratorLocations)
             {
@@ -53,6 +55,8 @@ public static class Backup
 
             FileSystemUtility.ReplaceDirectory(info.RoslynLocation, with: BackupLocation(backupPath, info.RoslynLocation, relativeTo: info.ContentLocation));
             FileSystemUtility.ReplaceDirectory(info.RuntimeLocation, with: BackupLocation(backupPath, info.RuntimeLocation, relativeTo: info.ContentLocation));
+            RestoreDirectoryIfExists(info.DotNetSdkHostLocation, backupPath, info.ContentLocation);
+            RestoreDirectoryIfExists(info.DotNetSdkSharedLocation, backupPath, info.ContentLocation);
 
             foreach (var sourceGeneratorLocation in info.SourceGeneratorLocations)
             {
@@ -73,5 +77,25 @@ public static class Backup
     {
         var relativeLocation = Path.GetRelativePath(relativeTo, location);
         return Path.Combine(backupLocation, relativeLocation);
+    }
+
+    private static void BackupDirectoryIfExists(string? directory, string backupPath, string contentLocation)
+    {
+        if (string.IsNullOrEmpty(directory) || !Directory.Exists(directory))
+        {
+            return;
+        }
+
+        FileSystemUtility.CopyDirectory(directory, BackupLocation(backupPath, directory, relativeTo: contentLocation));
+    }
+
+    private static void RestoreDirectoryIfExists(string? directory, string backupPath, string contentLocation)
+    {
+        if (string.IsNullOrEmpty(directory))
+        {
+            return;
+        }
+
+        FileSystemUtility.ReplaceDirectory(directory, with: BackupLocation(backupPath, directory, relativeTo: contentLocation));
     }
 }

--- a/UnityEditorPatch/Interactors/DotNetPatch.cs
+++ b/UnityEditorPatch/Interactors/DotNetPatch.cs
@@ -12,6 +12,8 @@ public class DotNetPatch
         {
             FileSystemUtility.ReplaceDirectory(editorInfo.RuntimeLocation, with: sdkInfo.Location);
             FileSystemUtility.ReplaceDirectory(editorInfo.RoslynLocation, with: sdkInfo.RoslynLocation);
+            CopyDotNetSdkRuntimeSupport(editorInfo.DotNetSdkHostLocation, sdkInfo.Location, "host");
+            CopyDotNetSdkRuntimeSupport(editorInfo.DotNetSdkSharedLocation, sdkInfo.Location, "shared");
         }
         catch (Exception)
         {
@@ -19,5 +21,21 @@ public class DotNetPatch
         }
 
         return true;
+    }
+
+    private static void CopyDotNetSdkRuntimeSupport(string? targetDirectory, string sdkRoot, string subdirectory)
+    {
+        if (string.IsNullOrEmpty(targetDirectory))
+        {
+            return;
+        }
+
+        var sourceDirectory = Path.Combine(sdkRoot, subdirectory);
+        if (!Directory.Exists(sourceDirectory))
+        {
+            return;
+        }
+
+        FileSystemUtility.CopyDirectory(sourceDirectory, targetDirectory);
     }
 }


### PR DESCRIPTION
Hey, here is a solution I came up with for the upcoming Unity 6.5 release. They slightly changed the way Roslyn is resolved. 
Now there is something like `Editor\Data\DotNetSdk\sdk\8.0.318\Roslyn\bincore`. 